### PR TITLE
feat: Add API to fetch user's unlocked properties

### DIFF
--- a/controllers/users.controller.js
+++ b/controllers/users.controller.js
@@ -107,4 +107,36 @@ const uploadUserAvatar = async (req, res) => {
   }
 };
 
-module.exports = { getAllUsers, getUserById, updateUserById, uploadUserAvatar };
+const getUserUnlockedProperty = async (req, res) => {
+  try {
+    const user = await req.user;
+
+    if (!user) {
+      return res.status(404).json({
+        message: "User not found",
+        status: 404,
+      });
+    }
+
+    const unlockedProperties = await Property.find({
+      _id: { $in: user.unlockedProperties },
+    }).populate("images", "url");
+
+    res.status(200).json({
+      message: "Unlocked properties fetched successfully",
+      status: 200,
+      count: unlockedProperties.length,
+      data: unlockedProperties,
+    });
+  } catch (error) {
+    console.log("get user unlocked property error", error);
+  }
+};
+
+module.exports = {
+  getAllUsers,
+  getUserById,
+  updateUserById,
+  uploadUserAvatar,
+  getUserUnlockedProperty,
+};

--- a/routes/usersRoute.js
+++ b/routes/usersRoute.js
@@ -6,10 +6,12 @@ const {
   getUserById,
   updateUserById,
   uploadUserAvatar,
+  getUserUnlockedProperty,
 } = require("../controllers/users.controller");
 const upload = require("../middleware/multer");
 
 router.get("/", getAllUsers);
+router.get("/unlocked-property", getUserUnlockedProperty);
 router.get("/:id", getUserById);
 router.put("/:id", updateUserById);
 router.put("/:id/avatar", upload.array("avatar"), uploadUserAvatar);


### PR DESCRIPTION
- Implemented `getUserUnlockedProperty` to allow users to retrieve their unlocked properties.
- Validates user authentication before proceeding with property retrieval.
- Fetches properties based on `user.unlockedProperties` and populates associated `images` with URLs.
- Returns a success response with the count and data of unlocked properties.
- Includes error handling to log and manage unexpected issues during execution.